### PR TITLE
Follow users dev

### DIFF
--- a/angularSTEP/src/app/converter.ts
+++ b/angularSTEP/src/app/converter.ts
@@ -14,7 +14,7 @@ export class Converter {
         username: user.username,
         email: user.email,
         picUrl: user.picUrl,
-        timestamp: user.time,
+        time: user.time,
         recipes: user.recipes,
         wishlist: user.wishlist,
         shoppingList: user.shoppingList,

--- a/angularSTEP/src/app/current-profile-page/current-profile-page.component.ts
+++ b/angularSTEP/src/app/current-profile-page/current-profile-page.component.ts
@@ -19,7 +19,7 @@ export class CurrentProfilePageComponent implements OnInit {
   user!: User;
 
   constructor(
-    public fAuth: AngularFireAuth,
+    private fAuth: AngularFireAuth,
     private router: Router,
     private route: ActivatedRoute,
     private afs: AngularFirestore,

--- a/angularSTEP/src/app/email/email.component.ts
+++ b/angularSTEP/src/app/email/email.component.ts
@@ -15,7 +15,7 @@ export class EmailComponent implements OnInit {
   logInForm: FormGroup;
 
   constructor(
-    public fAuth: AngularFireAuth,
+    private fAuth: AngularFireAuth,
     private router: Router,
     private fb: FormBuilder
   ) {

--- a/angularSTEP/src/app/home/home.component.ts
+++ b/angularSTEP/src/app/home/home.component.ts
@@ -12,7 +12,7 @@ import { AngularFireAuth } from '@angular/fire/auth';
 })
 export class HomeComponent implements OnInit {
 
-  constructor(public fAuth: AngularFireAuth, private afs: AngularFirestore) {}
+  constructor(private fAuth: AngularFireAuth, private afs: AngularFirestore) {}
 
   ngOnInit() {}
 }

--- a/angularSTEP/src/app/login/login.component.ts
+++ b/angularSTEP/src/app/login/login.component.ts
@@ -18,7 +18,7 @@ export class LoginComponent implements OnInit {
   //and there is no user in the database linked to the account
   //it will delete the user (in case user refreshes page before
   //setting a username but after signing in with Google
-  constructor(public fAuth: AngularFireAuth, public router: Router) {}
+  constructor(private fAuth: AngularFireAuth, private router: Router) {}
 
   //checks if google user is new, if so, calls setup component to
   //allow the user to create a username, if not new, redirects to home page

--- a/angularSTEP/src/app/profile-menu/profile-menu.component.ts
+++ b/angularSTEP/src/app/profile-menu/profile-menu.component.ts
@@ -20,7 +20,7 @@ export class ProfileMenuComponent implements OnInit {
   routerCheck!: Subscription;
 
   constructor(
-    public fAuth: AngularFireAuth,
+    private fAuth: AngularFireAuth,
     private router: Router,
     private afs: AngularFirestore,
     private zone: NgZone

--- a/angularSTEP/src/app/setup/setup.component.ts
+++ b/angularSTEP/src/app/setup/setup.component.ts
@@ -21,7 +21,7 @@ export class SetupComponent implements OnInit {
   picUrl = '';
 
   constructor(
-    public fAuth: AngularFireAuth,
+    private fAuth: AngularFireAuth,
     private router: Router,
     private fb: FormBuilder,
     private afs: AngularFirestore

--- a/angularSTEP/src/app/setup/setup.component.ts
+++ b/angularSTEP/src/app/setup/setup.component.ts
@@ -37,12 +37,6 @@ export class SetupComponent implements OnInit {
   //creates and adds a user to Firestore
   addUser(dName: string, email: string, uid: string) {
     return this.afs
-      .collection('usernames')
-      .doc(this.usernameForm.value.username)
-      .ref.withConverter(new Converter().usernameConverter)
-      .set(new Username(this.usernameForm.value.username, uid))
-      .then(() => {
-        this.afs
           .collection('users')
           .doc(uid)
           .ref.withConverter(new Converter().userConverter)
@@ -61,7 +55,13 @@ export class SetupComponent implements OnInit {
             )
           )
           .then(() => {
-            this.router.navigate(['/home']);
+            this.afs
+            .collection('usernames')
+            .doc(this.usernameForm.value.username)
+            .ref.withConverter(new Converter().usernameConverter)
+            .set(new Username(this.usernameForm.value.username, uid))
+            .then(() => {
+              this.router.navigate(['/home']);
           });
       });
   }

--- a/angularSTEP/src/app/signup/signup.component.ts
+++ b/angularSTEP/src/app/signup/signup.component.ts
@@ -78,12 +78,6 @@ export class SignupComponent implements OnInit {
   //creates the user and adds it to Firestore
   addUser(uid: string) {
     return this.afs
-      .collection('usernames')
-      .doc(this.signUpForm.value.username)
-      .ref.withConverter(new Converter().usernameConverter)
-      .set(new Username(this.signUpForm.value.username, uid))
-      .then(() => {
-        this.afs
           .collection('users')
           .doc(uid)
           .ref.withConverter(new Converter().userConverter)
@@ -102,7 +96,13 @@ export class SignupComponent implements OnInit {
             )
           )
           .then(() => {
-            this.router.navigate(['/home']);
+            this.afs
+            .collection('usernames')
+            .doc(this.signUpForm.value.username)
+            .ref.withConverter(new Converter().usernameConverter)
+            .set(new Username(this.signUpForm.value.username, uid))
+            .then(() => {
+              this.router.navigate(['/home']);
           });
       });
   }

--- a/angularSTEP/src/app/signup/signup.component.ts
+++ b/angularSTEP/src/app/signup/signup.component.ts
@@ -19,7 +19,7 @@ export class SignupComponent implements OnInit {
   picUrl = '';
 
   constructor(
-    public fAuth: AngularFireAuth,
+    private fAuth: AngularFireAuth,
     private router: Router,
     private fb: FormBuilder,
     private afs: AngularFirestore

--- a/angularSTEP/src/app/user-page/user-page.component.html
+++ b/angularSTEP/src/app/user-page/user-page.component.html
@@ -4,6 +4,8 @@
         <div class="name-header">
             <h1>{{ displayName }}</h1>
             <h3>@{{ username }}</h3>
+            <button *ngIf='!userFollowing && loggedIn' (click)='follow()' mat-button color="primary">Follow <mat-icon>check</mat-icon></button>
+            <button *ngIf='userFollowing && loggedIn' (click)='unfollow()' mat-button color="accent">Unfollow <mat-icon>close</mat-icon></button>
         </div>
     </div>
     <button mat-button routerLink="/users">Back</button>

--- a/angularSTEP/src/app/view-profiles/view-profiles.component.ts
+++ b/angularSTEP/src/app/view-profiles/view-profiles.component.ts
@@ -2,7 +2,7 @@ import {
   AngularFirestore,
   AngularFirestoreCollection,
 } from '@angular/fire/firestore';
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, NgZone} from '@angular/core';
 
 import {AngularFireAuth} from '@angular/fire/auth';
 import {Observable} from 'rxjs';
@@ -22,7 +22,8 @@ export class ViewProfilesComponent implements OnInit {
   constructor(
     public fAuth: AngularFireAuth,
     private router: Router,
-    private afs: AngularFirestore
+    private afs: AngularFirestore,
+    private zone: NgZone
   ) {
     this.userCollection = this.afs.collection('users');
     this.users = this.userCollection.valueChanges();
@@ -37,7 +38,9 @@ export class ViewProfilesComponent implements OnInit {
   }
 
   goToUser(username: string) {
-    this.router.navigate(['users/' + username]);
+    this.zone.run(() => {
+      this.router.navigate(['users/', username]);
+    })
   }
 
   ngOnInit() {}

--- a/angularSTEP/src/app/view-profiles/view-profiles.component.ts
+++ b/angularSTEP/src/app/view-profiles/view-profiles.component.ts
@@ -20,7 +20,7 @@ export class ViewProfilesComponent implements OnInit {
   users: Observable<User[]>;
 
   constructor(
-    public fAuth: AngularFireAuth,
+    private fAuth: AngularFireAuth,
     private router: Router,
     private afs: AngularFirestore,
     private zone: NgZone


### PR DESCRIPTION
This PR adds:

- follow and unfollow buttons for users
- if user is signed out, will not show buttons
- communicates with auth and firestore to add and remove users from following array

Something we might want is a map instead of an array. It will improve time complexity for following and unfollowing. However, if a User deletes their account, to remove this account from the following list would be harder. With an array you can use the .where("following", "array-containes", "uid") and get all of the documents very easily? This also is a less common practice though.
